### PR TITLE
Rasterio usage correction 1

### DIFF
--- a/source/notebooks/L5/clipping-raster.ipynb
+++ b/source/notebooks/L5/clipping-raster.ipynb
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_meta = data.profile",
+    "out_meta = data.profile\n",
     "out_meta.update({\"driver\": \"GTiff\",\n",
     "                 \"height\": out_img.shape[1],\n",
     "                 \"width\": out_img.shape[2],\n",

--- a/source/notebooks/L5/clipping-raster.ipynb
+++ b/source/notebooks/L5/clipping-raster.ipynb
@@ -231,33 +231,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Next, we need to modify the metadata. Let's start by copying the metadata from the original data file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 8877, 'height': 8106, 'count': 7, 'crs': CRS({'init': 'epsg:32634'}), 'transform': Affine(28.5, 0.0, 600466.5,\n",
-      "       0.0, -28.5, 6784966.5)}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Copy the metadata\n",
-    "out_meta = data.meta.copy()\n",
-    "print(out_meta)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "- Next we need to parse the EPSG value from the CRS so that we can create a `Proj4` -string using `PyCRS` library (to ensure that the projection information is saved correctly)."
    ]
   },
@@ -293,6 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "out_meta = data.profile
     "out_meta.update({\"driver\": \"GTiff\",\n",
     "                 \"height\": out_img.shape[1],\n",
     "                 \"width\": out_img.shape[2],\n",

--- a/source/notebooks/L5/clipping-raster.ipynb
+++ b/source/notebooks/L5/clipping-raster.ipynb
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_meta = data.profile
+    "out_meta = data.profile",
     "out_meta.update({\"driver\": \"GTiff\",\n",
     "                 \"height\": out_img.shape[1],\n",
     "                 \"width\": out_img.shape[2],\n",


### PR DESCRIPTION
Good morning! I saw this notebook referenced by a rasterio user and saw a usage correction that should be made. Code like `out_profile = dataset.profile.copy()` is better written as `out_profile = dataset.profile`. Modifying `out_profile` never modifies the dataset itself and never has.