### PR TITLE
Rasterio usage correction 2

### DIFF
--- a/source/notebooks/L5/clipping-raster.ipynb
+++ b/source/notebooks/L5/clipping-raster.ipynb
@@ -258,33 +258,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Next we need to parse the EPSG value from the CRS so that we can create a `Proj4` -string using `PyCRS` library (to ensure that the projection information is saved correctly)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "32634\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Parse EPSG code\n",
-    "epsg_code = int(data.crs.data['init'][5:])\n",
-    "print(epsg_code)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- Now we need to update the metadata with new dimensions, transform (affine) and CRS (as Proj4 text):"
+    "- Now we need to update the metadata with new dimensions, transform (affine):"
    ]
   },
   {
@@ -297,7 +271,6 @@
     "                 \"height\": out_img.shape[1],\n",
     "                 \"width\": out_img.shape[2],\n",
     "                 \"transform\": out_transform,\n",
-    "                 \"crs\": pycrs.parser.from_epsg_code(epsg_code).to_proj4()}\n",
     "                         )"
    ]
   },


### PR DESCRIPTION
Hi! There's no need for pycrs in this example. We can let the output dataset inherit CRS precisely from the source.